### PR TITLE
Add docker image that provides git repos as volumes

### DIFF
--- a/docker/git-puller/Dockerfile
+++ b/docker/git-puller/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine/git
+
+COPY bin/entrypoint.sh /
+COPY bin/ssh-askpass.sh /
+COPY README.md /
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/docker/git-puller/README.md
+++ b/docker/git-puller/README.md
@@ -1,0 +1,44 @@
+# git-puller
+
+Clones the given list of git repositories into the specified docker volume.
+
+## Usage
+
+```
+docker run
+  -v <VOLUME_NAME>:/git-puller
+  -e GIT_REPOS=<GIT_REPOS>
+  -e PRIVATE_KEY_PATH=<PRIVATE_KEY_PATH>
+  [-e PRIVATE_KEY_PASS=<PRIVATE_KEY_PASS>]
+  [-e GIT_CLONE_BARE=yes]
+  git-puller
+```
+
+## Parameters
+
+- VOLUME_NAME:      The name of the docker volume in which you want the git repositories to be cloned to.
+- GIT_REPOS:        A comma separated list of git repositories to clone.
+- PRIVATE_KEY_PATH: The path to the private key.
+- PRIVATE_KEY_PATH: Optional. The passphrase to the private key.
+- GIT_CLONE_BARE:   Optional. If defined, does a bare git clone.
+
+## Examples
+
+In its simplest form it can be run with:
+
+```
+docker run
+  -v gitkv-volume:/git-puller
+  -v ~/.ssh/id_rsa:/id_rsa
+  -e GIT_REPOS=git@github.com:intenthq/gitkv.git,git@github.com:intenthq/anon.git
+  -e PRIVATE_KEY_PATH=/id_rsa
+  git-puller
+```
+
+Providing a private key passphrase is supported by using the `PRIVATE_KEY_PASS` env variable:
+
+```
+docker run (...) -e PRIVATE_KEY_PASS=“supersecretpass” git-puller
+```
+
+If the env var `GIT_CLONE_BARE` is defined, a bare clone is done instead of a regular clone.

--- a/docker/git-puller/bin/entrypoint.sh
+++ b/docker/git-puller/bin/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -e
+
+if [ -z $GIT_REPOS ] || [ -z $PRIVATE_KEY_PATH ]; then
+  echo "Missing required parameters."
+  echo "You need to define both the GIT_REPOS and PRIVATE_KEY_PATH env variables."
+  cat /README.md
+  exit 1
+fi
+
+# Adds some common hosts keys to the known hosts file
+for host in "github.com gitlab.com bitbucket.org"; do
+  ssh-keyscan -H $host > /etc/ssh/ssh_known_hosts
+done
+
+# Tells git to use the provided private key
+export GIT_SSH_COMMAND="ssh -i ${PRIVATE_KEY_PATH}"
+
+# Provides private key passphrase instead of prompting the user
+export SSH_ASKPASS=/ssh-askpass.sh
+
+# Needs setting DISPLAY so that the script specified by SSH_ASKPASS is run
+export DISPLAY=:0
+
+cd /git-puller
+
+BARE_ARG=${GIT_CLONE_BARE:+"--bare"}
+IFS=,; for repo in $GIT_REPOS; do
+  git clone ${BARE_ARG} ${repo}
+done

--- a/docker/git-puller/bin/ssh-askpass.sh
+++ b/docker/git-puller/bin/ssh-askpass.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "$PRIVATE_KEY_PASS"


### PR DESCRIPTION
First stab at https://github.com/intenthq/gitkv/issues/6. This docker image populates a docker volume by git cloning the passed in repositories.

Assuming:
```
docker build -t git-puller path/to/gitkv/docker/git-puller
```

In its simplest form it can be run with:
```
docker run
  -v <volume-name>:/git-puller
  git-puller
  <repos-list>
```
Where `volume-name` is the name of the docker volume where you want the repos to be cloned to, if it doesn't exist yet it'll be created. And `repos-list` is the list of git repositories to clone, separated by spaces.

For instance:
```
docker run
 -v gitkv-volume:/git-puller
 git-puller
 https://github.com/intenthq/gitkv.git https://github.com/intenthq/anon.git
```
----------------------------

If credentials are needed for cloning the repositories, providing a private key is supported by using the `PRIVATE_KEY_PATH` env var and, optionally, the `PRIVATE_KEY_PASS` env var for passing in the private key's passphrase. For instance:
```
docker run
 -v gitkv-volume:/git-puller
 -v ~/.ssh/id_rsa:/id_rsa
 -e PRIVATE_KEY_PATH=/id_rsa
 -e PRIVATE_KEY_PASS=“supersecretpass”
 git-puller
 git@github.com:intenthq/gitkv.git git@github.com:intenthq/anon.git
```
----------------------------

An extra env var `GIT_CLONE_BARE` can be provided to do a bare clone instead of a regular clone.