### PR TITLE
Init repo list

### DIFF
--- a/git/src/lib.rs
+++ b/git/src/lib.rs
@@ -52,7 +52,6 @@ pub fn load_repos(root_path: &Path) -> HashMap<String, Repository> {
                 }
             })
         })
-        .into_iter()
         .collect()
 }
 

--- a/handlers/Cargo.toml
+++ b/handlers/Cargo.toml
@@ -7,10 +7,7 @@ license = "MIT"
 
 [dependencies]
 git = { path = "../git" }
-actix-web = "^0.7.18"
-git2 = "^0.8.0"
-serde = "^1.0.89"
-serde_derive = "^1.0.89"
+actix = "^0.7.9"
 
 # When building for musl (ie. a static binary), we opt into the "vendored"
 # feature flag of openssl-sys which compiles libopenssl statically for us.

--- a/handlers/src/lib.rs
+++ b/handlers/src/lib.rs
@@ -64,7 +64,7 @@ impl Handler<CatFile> for GitRepos {
                 .ops
                 .cat_file(repo, &task.reference, &task.filename)
                 .map_err(|x| x.to_string()),
-            None => Err("No repo found".to_string()),
+            None => Err(format!("No repo found with name {}", &task.repo_key)),
         })
     }
 }

--- a/handlers/src/lib.rs
+++ b/handlers/src/lib.rs
@@ -1,100 +1,70 @@
-#[macro_use]
-extern crate serde_derive;
+use actix::dev::{MessageResponse, ResponseChannel};
+use actix::{Actor, Context, Handler, Message};
+use git::{git2::Repository, GitOps, LibGitOps};
+use std::collections::HashMap;
 
-use actix_web::{dev::Handler, Binary, FromRequest, HttpRequest, Path, Query};
-use git::{LibGitOps, GitOps};
-use std::path::PathBuf;
-
-#[derive(Deserialize)]
-pub struct PathParams {
-    repo: String,
+pub struct CatFile {
+    pub repo_key: String,
+    pub reference: String,
+    pub filename: String,
 }
 
-#[derive(Deserialize)]
-pub struct QueryParams {
-    reference: String,
-    file: String,
-}
-
-pub struct RepoHandler {
-    pub repo_root: String,
-    git_ops: Box<GitOps>,
-}
-
-impl<S> Handler<S> for RepoHandler {
-    type Result = Binary;
-
-    fn handle(&self, req: &HttpRequest<S>) -> Self::Result {
-        //TODO https://actix.rs/docs/errors/
-        let path_params = Path::<PathParams>::extract(req).expect("Wrong path params");
-        let query_params = Query::<QueryParams>::extract(req).expect("Wront query params");
-        let repo_path: PathBuf = [&self.repo_root, &path_params.repo].iter().collect();
-        let reference = format!("refs/{}", query_params.reference);
-        //TODO return proper content type depending on the content of the blob
-        self.git_ops
-            .cat_file(&repo_path, &reference, &query_params.file)
-            .map(Binary::from)
-            .expect("Can't cat file")
-    }
-}
-
-impl RepoHandler {
-    pub fn new(repo_root: String) -> RepoHandler {
-        RepoHandler {
-            repo_root,
-            git_ops: Box::new(LibGitOps {}),
+impl CatFile {
+    pub fn new(repo_key: String, reference: String, filename: String) -> CatFile {
+        CatFile {
+            repo_key,
+            filename,
+            reference,
         }
     }
 }
 
-#[cfg(test)]
-mod tests {
+impl Message for CatFile {
+    type Result = CatFileResponse;
+}
 
-    use super::RepoHandler;
-    use actix_web::http::StatusCode;
-    use actix_web::test;
-    use actix_web::{Binary, Body};
-    use git::GitOps;
-    use std::path;
+pub struct CatFileResponse(pub Result<Vec<u8>, String>);
 
-    struct TestGitOps {
-        res: Vec<u8>,
-    }
-
-    impl GitOps for TestGitOps {
-        fn cat_file(
-            &self,
-            _repo_path: &path::Path,
-            _reference: &str,
-            _filename: &str,
-        ) -> Result<Vec<u8>, git2::Error> {
-            Ok(self.res.to_owned())
+impl<A, M> MessageResponse<A, M> for CatFileResponse
+where
+    A: Actor,
+    M: Message<Result = CatFileResponse>,
+{
+    fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
+        if let Some(tx) = tx {
+            tx.send(self);
         }
     }
+}
 
-    fn bin_ref(body: &Body) -> &Binary {
-        match *body {
-            Body::Binary(ref bin) => bin,
-            _ => panic!(),
+pub struct GitRepos {
+    repos: HashMap<String, Repository>,
+    ops: Box<GitOps>,
+}
+
+impl Actor for GitRepos {
+    type Context = Context<Self>;
+}
+
+impl GitRepos {
+    pub fn new(repos: HashMap<String, Repository>) -> GitRepos {
+        GitRepos {
+            repos,
+            ops: Box::new(LibGitOps {}),
         }
     }
+}
 
-    #[test]
-    fn it_returns_the_content_of_the_file_by_cat_file() {
-        let rp = RepoHandler {
-            repo_root: "not-used".to_string(),
-            git_ops: Box::new(TestGitOps {
-                res: b"hello".to_vec(),
-            }),
-        };
+impl Handler<CatFile> for GitRepos {
+    type Result = CatFileResponse;
 
-        let resp = test::TestRequest::with_header("content-type", "application/json")
-            .param("repo", "client-config.git")
-            .uri("/repo/?reference=the-reference&file=the-file")
-            .run(&rp)
-            .expect("can't run test request");
-        assert_eq!(resp.status(), StatusCode::OK);
-        assert_eq!(bin_ref(resp.body()), &Binary::from_slice(b"hello"));
+    fn handle(&mut self, task: CatFile, _: &mut Self::Context) -> Self::Result {
+        CatFileResponse(match self.repos.get(&task.repo_key) {
+            Some(repo) => self
+                .ops
+                .cat_file(repo, &task.reference, &task.filename)
+                .map_err(|x| x.to_string()),
+            None => Err("No repo found".to_string()),
+        })
     }
-
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,7 +11,7 @@ git = { path = "../git" }
 handlers = { path = "../handlers" }
 actix-web = "^0.7.18"
 clap = "^2.32.0"
-futures = "0.1"
+futures = "^0.1.26"
 serde = "^1.0.89"
 serde_derive = "^1.0.89"
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,11 +7,13 @@ edition = "2018"
 license = "MIT"
 
 [dependencies]
+git = { path = "../git" }
 handlers = { path = "../handlers" }
 actix-web = "^0.7.18"
 clap = "^2.32.0"
-git2 = "^0.8.0"
-listenfd = "^0.3.3"
+futures = "0.1"
+serde = "^1.0.89"
+serde_derive = "^1.0.89"
 
 # When building for musl (ie. a static binary), we opt into the "vendored"
 # feature flag of openssl-sys which compiles libopenssl statically for us.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -43,7 +43,7 @@ pub struct AppState {
 fn run_server(host: &str, port: &str, repo_root: &Path) {
     let _sys = System::new("gitkv-server");
 
-    let addr = GitRepos::new(git::load_repos(&repo_root).expect("can't load repos")).start();
+    let addr = GitRepos::new(git::load_repos(&repo_root)).start();
 
     let listen_address = format!("{}:{}", host, port);
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -61,7 +61,7 @@ fn run_server(host: &str, port: &str, repo_root: &Path) {
 fn get_repo(req: &HttpRequest<AppState>) -> impl Responder {
     //TODO https://actix.rs/docs/errors/
     let path_params = actix_web::Path::<PathParams>::extract(req).expect("Wrong path params");
-    let query_params = actix_web::Query::<QueryParams>::extract(req).expect("Wront query params");
+    let query_params = actix_web::Query::<QueryParams>::extract(req).expect("Wrong query params");
     let repo_key = path_params.repo.to_string();
     let filename = query_params.file.to_string();
     let reference = format!("refs/{}", query_params.reference);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -13,6 +13,7 @@ use std::path::Path;
 const DEFAULT_PORT: &str = "7791";
 const DEFAULT_HOST: &str = "localhost";
 const DEFAULT_REPO_ROOT: &str = "./";
+const DEFAULT_REFERENCE: &str = "heads/master";
 
 fn main() {
     let args = parse_args().get_matches();
@@ -31,7 +32,7 @@ pub struct PathParams {
 
 #[derive(Deserialize)]
 pub struct QueryParams {
-    pub reference: String,
+    pub reference: Option<String>,
     pub file: String,
 }
 
@@ -64,7 +65,13 @@ fn get_repo(req: &HttpRequest<AppState>) -> impl Responder {
     let query_params = actix_web::Query::<QueryParams>::extract(req).expect("Wrong query params");
     let repo_key = path_params.repo.to_string();
     let filename = query_params.file.to_string();
-    let reference = format!("refs/{}", query_params.reference);
+    let reference = format!(
+        "refs/{}",
+        query_params
+            .reference
+            .as_ref()
+            .unwrap_or(&DEFAULT_REFERENCE.to_string())
+    );
     let gr: &Addr<GitRepos> = &req.state().git_repos;
     //TODO return proper content type depending on the content of the blob
     gr.send(CatFile {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -63,14 +63,15 @@ fn get_repo(req: &HttpRequest<AppState>) -> impl Responder {
     //TODO https://actix.rs/docs/errors/
     let path_params = actix_web::Path::<PathParams>::extract(req).expect("Wrong path params");
     let query_params = actix_web::Query::<QueryParams>::extract(req).expect("Wrong query params");
-    let repo_key = path_params.repo.to_string();
-    let filename = query_params.file.to_string();
+    let repo_key = path_params.repo.clone();
+    let filename = query_params.file.clone();
     let reference = format!(
         "refs/{}",
         query_params
             .reference
             .as_ref()
-            .unwrap_or(&DEFAULT_REFERENCE.to_string())
+            .map(String::as_str)
+            .unwrap_or(DEFAULT_REFERENCE)
     );
     let gr: &Addr<GitRepos> = &req.state().git_repos;
     //TODO return proper content type depending on the content of the blob

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -75,16 +75,16 @@ fn get_repo(req: &HttpRequest<AppState>) -> impl Responder {
     let gr: &Addr<GitRepos> = &req.state().git_repos;
     //TODO return proper content type depending on the content of the blob
     gr.send(CatFile {
-            repo_key,
-            filename,
-            reference,
-        })
-        .map(|x| {
-            x.0.map(Binary::from)
-                .map_err(|e| actix_web::error::InternalError::new(e, http::StatusCode::NOT_FOUND))
-        })
-        //TODO don't wait and return the future itself
-        .wait()
+        repo_key,
+        filename,
+        reference,
+    })
+    .map(|x| {
+        x.0.map(Binary::from)
+            .map_err(|e| actix_web::error::InternalError::new(e, http::StatusCode::NOT_FOUND))
+    })
+    //TODO don't wait and return the future itself
+    .wait()
 }
 
 fn parse_args<'a, 'b>() -> clap::App<'a, 'b> {


### PR DESCRIPTION
Restricts git repos to a pre-defined selection, as per #12. Worth noting there's no tests for `load_repos`. Do we want to test this method and if so how?

This PR also:
- Makes the git reference parameter optional (defaulting master)
- Fixes a typo