### PR TITLE
Add logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ OPTIONS:
     -p, --port <PORT>    port to listen to [default: 7791]
 ```
 
+You can modify the amount of logging with the `RUST_LOG` parameter:
+
+For basic application info (default): `RUST_LOG=gitkv=info ./gitkv`  
+Including incoming HTTP requests: `RUST_LOG=info ./gitkv`  
+For more information check [env_logger](https://docs.rs/env_logger/*/env_logger/index.html)'s documentation.
+
 ## Security
 
 Note that git stores all the content plain so that it's not a good place to store secrets and sensitive information.

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,6 +14,8 @@ clap = "^2.32.0"
 futures = "^0.1.26"
 serde = "^1.0.89"
 serde_derive = "^1.0.89"
+log = "^0.4.6"
+env_logger = "^0.6.1"
 
 # When building for musl (ie. a static binary), we opt into the "vendored"
 # feature flag of openssl-sys which compiles libopenssl statically for us.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -7,8 +7,6 @@ extern crate actix_web;
 extern crate log;
 extern crate env_logger;
 
-use log::Level;
-
 use actix_web::actix::{Actor, Addr, System};
 use actix_web::{http, middleware, server, App, Binary, FromRequest, HttpRequest, Responder};
 use env_logger::Env;
@@ -53,14 +51,7 @@ fn run_server(host: &str, port: &str, repo_root: &Path) {
 
     let repos = git::load_repos(&repo_root);
 
-    if log_enabled!(Level::Info) {
-        let keys = repos
-            .keys()
-            .map(|key| (*key).clone())
-            .collect::<Vec<String>>();
-
-        info!("Loaded Git repos: [{}]", keys.join(", "))
-    }
+    info!("Loaded Git repos: {:?}", repos.keys());
 
     let addr = GitRepos::new(repos).start();
     let listen_address = format!("{}:{}", host, port);


### PR DESCRIPTION
Thought I'd keep it simple with the first logging PR. We can add other info/debugging stuff as and when needed:
- Adds a logging library for proper management of log visibility
- Can now enable web logs with an env param
- Defaults to info level and only logs from gitkv itself
- Logs listening port/IP and loaded repos

Example log:
```
Kit:gitkv Kit$ cargo run -- --repo-root=/Users/Kit/Projects
   Compiling gitkv v0.1.0 (/Users/Kit/Projects/sandbox/gitkv/server)
    Finished dev [unoptimized + debuginfo] target(s) in 9.16s
     Running `target/debug/gitkv --repo-root=/Users/Kit/Projects`
[2019-04-15T13:35:30Z INFO  gitkv] Loaded Git repos: [Recibase, gitkv, anon, business-cat]
[2019-04-15T13:35:30Z INFO  gitkv] Listening on localhost:7791
``` 