### PR TITLE
Return proper HTTP errors

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -80,7 +80,8 @@ fn get_repo(req: &HttpRequest<AppState>) -> impl Responder {
                 query_params
                     .reference
                     .as_ref()
-                    .unwrap_or(&DEFAULT_REFERENCE.to_string())
+                    .map(String::as_str)
+                    .unwrap_or(&DEFAULT_REFERENCE)
             );
             let gr: &Addr<GitRepos> = &req.state().git_repos;
             // TODO return proper content type depending on the content of the blob


### PR DESCRIPTION
Returns HTTP 400 if required parameters are missing. HTTP 500 should be returned for all generic errors as per [the docs](https://actix.rs/docs/errors/):
>ResponseError has a default implementation for error_response() that will render a 500 (internal server error)

Closes #4 