### PR TITLE
Hide beta builds after last rust release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-
+dist: xenial
 os:
   - linux
 


### PR DESCRIPTION
Rust Beta builds are failing because of this.
https://github.com/rust-lang/rust/issues/59411
Until they fix it we'll allow Beta fails