### PR TITLE
Upgrade To `actix-web` v1.0.0

### DIFF
--- a/handlers/Cargo.toml
+++ b/handlers/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 git = { path = "../git" }
-actix = "^0.7.9"
+actix = "^0.8.3"
 
 # When building for musl (ie. a static binary), we opt into the "vendored"
 # feature flag of openssl-sys which compiles libopenssl statically for us.

--- a/handlers/src/lib.rs
+++ b/handlers/src/lib.rs
@@ -64,7 +64,7 @@ impl Handler<CatFile> for GitRepos {
                 .ops
                 .cat_file(repo, &task.reference, &task.filename)
                 .map_err(|x| x.to_string()),
-            None => Err(format!("No repo found with name {}", &task.repo_key)),
+            None => Err(format!("No repo found with name '{}'", &task.repo_key)),
         })
     }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,13 +9,18 @@ license = "MIT"
 [dependencies]
 git = { path = "../git" }
 handlers = { path = "../handlers" }
-actix-web = "^1.0.0"
+actix = "^0.8.3"
+actix-web = "^1.0.2"
 clap = "^2.32.0"
 futures = "^0.1.26"
 serde = "^1.0.89"
 serde_derive = "^1.0.89"
 log = "^0.4.6"
 env_logger = "^0.6.1"
+
+[dev-dependencies]
+actix-http = "^0.2.3"
+actix-http-test = "^0.2.2"
 
 # When building for musl (ie. a static binary), we opt into the "vendored"
 # feature flag of openssl-sys which compiles libopenssl statically for us.

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 [dependencies]
 git = { path = "../git" }
 handlers = { path = "../handlers" }
-actix-web = "^0.7.18"
+actix-web = "^1.0.0"
 clap = "^2.32.0"
 futures = "^0.1.26"
 serde = "^1.0.89"


### PR DESCRIPTION
Update `actix-web` requirement from `^0.7.18` to `^1.0.0`.

There were significant breaking changes described in the migration guide
at https://github.com/actix/actix-web/blob/master/MIGRATION.md#100 — and
a lot that weren't documented anywhere!

Some notable ones are:

* A new way to get at query and path params (which is much nicer,
admittedly).
* A completely new way to specify routes and middleware — the DSL is
basically entirely overhauled.
* Removal of the `TestServer` helpers from `actix-web` means you now
need to test through `actix-http-test` instead.
* We are now able to assert on the body of failed requests, meaning the
tests can check the actual error responses on those too.

