### PR TITLE
Fix failing beta builds by adding `dyn` to trait objects.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ addons:
 matrix:
   fast_finish: true
   allow_failures:
+    - rust: beta
     - rust: nightly
   include:
     - os: linux

--- a/handlers/src/lib.rs
+++ b/handlers/src/lib.rs
@@ -39,7 +39,7 @@ where
 
 pub struct GitRepos {
     repos: HashMap<String, Repository>,
-    ops: Box<GitOps>,
+    ops: Box<dyn GitOps>,
 }
 
 impl Actor for GitRepos {


### PR DESCRIPTION
Also, allow beta builds to fail without breaking the build — they should just be warnings.