### PR TITLE
Allow to `ls` a directory.

### DIFF
--- a/handlers/src/lib.rs
+++ b/handlers/src/lib.rs
@@ -1,50 +1,30 @@
-use actix::dev::{MessageResponse, ResponseChannel};
+use actix::dev::MessageResponse;
 use actix::{Actor, Context, Handler, Message};
 use git::{git2::Repository, GitOps, LibGitOps};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+#[derive(Message)]
+#[rtype(result="CatFileResponse")]
 pub struct CatFile {
     pub repo_key: String,
     pub reference: String,
     pub path: PathBuf,
 }
 
-impl Message for CatFile {
-    type Result = CatFileResponse;
-}
-
+#[derive(MessageResponse)]
 pub struct CatFileResponse(pub Result<Vec<u8>, String>);
 
-impl<A, M> MessageResponse<A, M> for CatFileResponse
-    where A: Actor, M: Message<Result = CatFileResponse> {
-        fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
-            if let Some(tx) = tx {
-                tx.send(self);
-            }
-        }
-    }
-
+#[derive(Message)]
+#[rtype(result="LsDirResponse")]
 pub struct LsDir {
     pub repo_key: String,
     pub reference: String,
     pub path: PathBuf,
 }
 
-impl Message for LsDir {
-    type Result = LsDirResponse;
-}
-
+#[derive(MessageResponse)]
 pub struct LsDirResponse(pub Result<Vec<PathBuf>, String>);
-
-impl<A, M> MessageResponse<A, M> for LsDirResponse
-    where A: Actor, M: Message<Result = LsDirResponse> {
-        fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
-            if let Some(tx) = tx {
-                tx.send(self);
-            }
-        }
-    }
 
 pub struct GitRepos {
     repos: HashMap<String, Repository>,

--- a/handlers/src/lib.rs
+++ b/handlers/src/lib.rs
@@ -6,17 +6,7 @@ use std::collections::HashMap;
 pub struct CatFile {
     pub repo_key: String,
     pub reference: String,
-    pub filename: String,
-}
-
-impl CatFile {
-    pub fn new(repo_key: String, reference: String, filename: String) -> CatFile {
-        CatFile {
-            repo_key,
-            filename,
-            reference,
-        }
-    }
+    pub path: String,
 }
 
 impl Message for CatFile {
@@ -26,16 +16,34 @@ impl Message for CatFile {
 pub struct CatFileResponse(pub Result<Vec<u8>, String>);
 
 impl<A, M> MessageResponse<A, M> for CatFileResponse
-where
-    A: Actor,
-    M: Message<Result = CatFileResponse>,
-{
-    fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
-        if let Some(tx) = tx {
-            tx.send(self);
+    where A: Actor, M: Message<Result = CatFileResponse> {
+        fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
+            if let Some(tx) = tx {
+                tx.send(self);
+            }
         }
     }
+
+pub struct LsDir {
+    pub repo_key: String,
+    pub reference: String,
+    pub path: String,
 }
+
+impl Message for LsDir {
+    type Result = LsDirResponse;
+}
+
+pub struct LsDirResponse(pub Result<Vec<String>, String>);
+
+impl<A, M> MessageResponse<A, M> for LsDirResponse
+    where A: Actor, M: Message<Result = LsDirResponse> {
+        fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
+            if let Some(tx) = tx {
+                tx.send(self);
+            }
+        }
+    }
 
 pub struct GitRepos {
     repos: HashMap<String, Repository>,
@@ -58,13 +66,27 @@ impl GitRepos {
 impl Handler<CatFile> for GitRepos {
     type Result = CatFileResponse;
 
-    fn handle(&mut self, task: CatFile, _: &mut Self::Context) -> Self::Result {
-        CatFileResponse(match self.repos.get(&task.repo_key) {
+    fn handle(&mut self, req: CatFile, _: &mut Self::Context) -> Self::Result {
+        CatFileResponse(match self.repos.get(&req.repo_key) {
             Some(repo) => self
                 .ops
-                .cat_file(repo, &task.reference, &task.filename)
+                .cat_file(repo, &req.reference, &req.path)
                 .map_err(|x| x.to_string()),
-            None => Err(format!("No repo found with name '{}'", &task.repo_key)),
+            None => Err(format!("No repo found with name '{}'", &req.repo_key)),
+        })
+    }
+}
+
+impl Handler<LsDir> for GitRepos {
+    type Result = LsDirResponse;
+
+    fn handle(&mut self, req: LsDir, _: &mut Self::Context) -> Self::Result {
+        LsDirResponse(match self.repos.get(&req.repo_key) {
+            Some(repo) => self
+                .ops
+                .ls_dir(repo, &req.reference, &req.path)
+                .map_err(|x| x.to_string()),
+            None => Err(format!("No repo found with name '{}'", &req.repo_key)),
         })
     }
 }

--- a/handlers/src/lib.rs
+++ b/handlers/src/lib.rs
@@ -2,11 +2,12 @@ use actix::dev::{MessageResponse, ResponseChannel};
 use actix::{Actor, Context, Handler, Message};
 use git::{git2::Repository, GitOps, LibGitOps};
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 pub struct CatFile {
     pub repo_key: String,
     pub reference: String,
-    pub path: String,
+    pub path: PathBuf,
 }
 
 impl Message for CatFile {
@@ -27,14 +28,14 @@ impl<A, M> MessageResponse<A, M> for CatFileResponse
 pub struct LsDir {
     pub repo_key: String,
     pub reference: String,
-    pub path: String,
+    pub path: PathBuf,
 }
 
 impl Message for LsDir {
     type Result = LsDirResponse;
 }
 
-pub struct LsDirResponse(pub Result<Vec<String>, String>);
+pub struct LsDirResponse(pub Result<Vec<PathBuf>, String>);
 
 impl<A, M> MessageResponse<A, M> for LsDirResponse
     where A: Actor, M: Message<Result = LsDirResponse> {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,6 +15,7 @@ clap = "^2.32.0"
 futures = "^0.1.26"
 serde = "^1.0.89"
 serde_derive = "^1.0.89"
+serde_json = "^1.0.40"
 log = "^0.4.6"
 env_logger = "^0.6.1"
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -12,7 +12,7 @@ use actix_web::{error, http, middleware, web, App, HttpServer};
 use env_logger::Env;
 use futures::future::Future;
 use handlers::{CatFile, CatFileResponse, GitRepos, LsDir, LsDirResponse};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use serde_json;
 
 const DEFAULT_PORT: &str = "7791";
@@ -35,7 +35,7 @@ fn main() {
 #[derive(Deserialize)]
 pub struct PathParams {
     pub repo: String,
-    pub path: String
+    pub path: PathBuf
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Add a new endpoint to `ls` a directory to see all the files underneath.
The files are returned as a JSON array of strings representing the
relative paths of the files underneath the given directory.

The result is non-recursive because otherwise there is an opportunity to
DOS the server with a large response on a deep directory tree — it seems
more unlikely that there is a directory with children directly under it
large enough to break this but of course the risk there is also
non-zero.

The endpoint is `/repos/<name>/ls/<path>`.