### PR TITLE
Add endpoint that returns commit sha given a valid reference

### DIFF
--- a/handlers/src/lib.rs
+++ b/handlers/src/lib.rs
@@ -90,8 +90,7 @@ impl Handler<ResolveRef> for GitRepos {
             Some(repo) => self
                 .ops
                 .resolve_ref(repo, &req.reference)
-                .map_err(|x| x.to_string())
-                .map(|id| id.to_string()),
+                .map_err(|x| x.to_string()),
             None => Err(format!("No repo found with name '{}'", &req.repo_key)),
         })
     }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -398,12 +398,14 @@ mod tests {
 
     // resolve tests
 
+    fn origin_master_sha() -> String { String::from("e6134971608eb6ba7eb29047d5884c3377bc1fd2") }
+
     #[test]
-    fn resolve_ref_with_commit_sha() {
+    fn resolve_ref_with_empty_reference() {
         assert_test_server_responds_with!(
-            "/repos/fixtures/resolve?reference=467e981f94686d7a1db395f8acfd3cf7e7adfcd3",
+            "/repos/fixtures/resolve",
             200,
-            "467e981f94686d7a1db395f8acfd3cf7e7adfcd3"
+            origin_master_sha()
         )
     }
 
@@ -412,7 +414,16 @@ mod tests {
         assert_test_server_responds_with!(
             "/repos/fixtures/resolve?reference=origin/master",
             200,
-            "e6134971608eb6ba7eb29047d5884c3377bc1fd2"
+            origin_master_sha()
+        )
+    }
+
+    #[test]
+    fn resolve_ref_with_commit_sha() {
+        assert_test_server_responds_with!(
+            "/repos/fixtures/resolve?reference=467e981f94686d7a1db395f8acfd3cf7e7adfcd3",
+            200,
+            "467e981f94686d7a1db395f8acfd3cf7e7adfcd3"
         )
     }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -399,9 +399,27 @@ mod tests {
     // resolve tests
 
     #[test]
-    fn resolve_ref_with_empty_repo() {
+    fn resolve_ref_with_commit_sha() {
         assert_test_server_responds_with!(
             "/repos/fixtures/resolve?reference=467e981f94686d7a1db395f8acfd3cf7e7adfcd3",
+            200,
+            "467e981f94686d7a1db395f8acfd3cf7e7adfcd3"
+        )
+    }
+
+    #[test]
+    fn resolve_ref_with_branch_name() {
+        assert_test_server_responds_with!(
+            "/repos/fixtures/resolve?reference=origin/master",
+            200,
+            "e6134971608eb6ba7eb29047d5884c3377bc1fd2"
+        )
+    }
+
+    #[test]
+    fn resolve_ref_with_tag() {
+        assert_test_server_responds_with!(
+            "/repos/fixtures/resolve?reference=v0.1.0",
             200,
             "467e981f94686d7a1db395f8acfd3cf7e7adfcd3"
         )


### PR DESCRIPTION
Adds a new endpoint that returns the specific commit sha of a given branch name or tag. 